### PR TITLE
Tests + Minor changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,6 @@ jobs:
         run: |
           forge --version
 
-      - name: Run Forge fmt
-        run: |
-          forge fmt --check
-        id: fmt
-
       - name: Run Forge build
         run: |
           forge build --sizes

--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@ Full information is available in the [wiki](https://github.com/guidedao/lottery-
 
 This project is built with **Foundry** framework for Solidity, so you can use all the tools included.
 
+Here are all the configuration values for the contracts (src/libraries/Configs.sol):
+
+```Solidity
+// Details: https://docs.chain.link/vrf/v2-5/overview/subscription
+library VRFConsumerConfig {
+    bytes32 constant KEY_HASH = <...>;
+    uint32 constant CALLBACK_GAS_LIMIT = <...>;
+    uint16 constant REQUEST_CONFIRMATIONS = <...>;
+}
+
+// Business logic
+library LotteryConfig {
+    uint256 constant INITIAL_TICKET_PRICE = <...>;
+    uint8 constant TARGET_PARTICIPANTS_NUMBER = <...>;
+    uint16 constant MAX_PARTICIPANTS_NUMBER = <...>;
+    uint256 constant REGISTRATION_DURATION = <...>;
+    uint256 constant MAX_EXTENSION_TIME = <...>;
+    uint256 constant REFUND_WINDOW = <...>;
+}
+```
+
+You probably won't need to change anything for your local setup, however you can do that if you want.
+
 ### Running Locally
 
 First, open two terminal tabs and run a local Ethereum node in any of them:
@@ -46,43 +69,15 @@ You will instantly need the VRF coordinator address to fund a subscription and r
 forge script script/local/FundSubscription.s.sol:FundSubscriptionScript --rpc-url http://localhost:8545 --broadcast --private-key <PRIVATE_KEY>
 ```
 
-Now you can properly set the VRF consumer config ([details](https://docs.chain.link/vrf/v2-5/overview/subscription)). You can also set ORGANIZER to your address if you want to conveniently work with results of functions, responsible for financial operations (e.g. withdrawOrganizerFunds or collectExpiredRefunds):
-
-```Solidity
-// src/libraries/Configs.sol
-
-library VRFConsumerConfig  {
-  // Both taken from {MocksDeployScript} logs (or
-  // Chainlink Subscription Manager if not testing locally)
-  address constant VRF_COORDINATOR = <COORDINATOR_ADDRESS>
-  uint256 constant SUBSCRIPTION_ID = <SUBSCRIPTION_ID>
-
-  // Indicates maximum gas price you are willing to pay,
-  // use arbitrary bytes32 value if running locally
-  bytes32 constant KEY_HASH = <KEY_HASH>
-  // ...
-}
-//...
-library LotteryConfig {
-  // You can also set this to your address
-  // during local testing if needed
-  address ORGANIZER = <ORGANIZER_ADDRESS>
-}
-```
-
-Don't forget to save changes.
-
-Then you have will have to deploy the lottery contract:
+Then you have will have to deploy the lottery contract (you will have to specify initial organizer and GuideDAO token address altogether with VRF coordinator address and subscription ID):
 
 ```bash
-// You will be asked to enter GuideDAO token address
 forge script script/LotteryDeploy.s.sol:LotteryDeployScript --rpc-url http://localhost:8545 --broadcast --private-key <PRIVATE_KEY>
 ```
 
-And add the lottery in VRF consumers list:
+And add the lottery in VRF consumers list (now you will need to provide the lottery and coordinator addresses and corresponding subscription ID):
 
 ```bash
-// Now you will need to provide the lottery address
 forge script script/AddConsumer.s.sol:AddConsumerScript --rpc-url http://localhost:8545 --broadcast --private-key <PRIVATE_KEY>
 ```
 
@@ -90,7 +85,7 @@ Now you have fully prepared local chain, and you can use [http://localhost:8545]
 
 ### Running in production or public testnets
 
-In this case you will only have to set config values (VRFConsumer, taken from Chainlink Subscription Manager, and lottery), and deploy the lottery contract in the same way as above.
+In this case you will only have to deploy the lottery contract in the same way as above.
 
 ## Code Quality
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,27 @@ To check code for linting errors, run:
 solhint ./**/*.sol
 ```
 
+## Tests
+
+To run tests, use:
+
+```bash
+forge test
+```
+
+To see tests coverage, use:
+
+```bash
+forge coverage
+```
+
+Or if you want to get detailed HTML report:
+
+```bash
+mnkdir coverage
+forge coverage  --report lcov --report-file coverage/lcov.info && genhtml coverage/lcov.info --branch-coverage --output-dir coverage
+```
+
 ## Project Structure
 
 The main source code is organized as follows:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ library LotteryConfig {
 }
 ```
 
-You probably won't need to change anything for your local setup, however you can do that if you want.
+You probably won't need to change anything for setting up locally, however, you can do that if you want.
 
 ### Running Locally
 
@@ -69,16 +69,16 @@ You will instantly need the VRF coordinator address to fund a subscription and r
 forge script script/local/FundSubscription.s.sol:FundSubscriptionScript --rpc-url http://localhost:8545 --broadcast --private-key <PRIVATE_KEY>
 ```
 
-Then you have will have to deploy the lottery contract (you will have to specify initial organizer and GuideDAO token address altogether with VRF coordinator address and subscription ID):
+Then you have will have to deploy the lottery contract (you will have to specify initial organizer and GuideDAO token address along with VRF coordinator address and subscription ID):
 
 ```bash
 forge script script/LotteryDeploy.s.sol:LotteryDeployScript --rpc-url http://localhost:8545 --broadcast --private-key <PRIVATE_KEY>
 ```
 
-And add the lottery in VRF consumers list (now you will need to provide the lottery and coordinator addresses and corresponding subscription ID):
+And add the lottery in VRF consumers list (now you will need to provide the lottery, GuideDAO NFT fallback recipient and coordinator addresses and corresponding subscription ID):
 
 ```bash
-forge script script/AddConsumer.s.sol:AddConsumerScript --rpc-url http://localhost:8545 --broadcast --private-key <PRIVATE_KEY>
+forge script script/local/AddConsumer.s.sol:AddConsumerScript --rpc-url http://localhost:8545 --broadcast --private-key <PRIVATE_KEY>
 ```
 
 Now you have fully prepared local chain, and you can use [http://localhost:8545](http://localhost:8545) as RPC URL for your purposes.

--- a/script/LotteryDeploy.s.sol
+++ b/script/LotteryDeploy.s.sol
@@ -20,6 +20,11 @@ contract LotteryDeployScript is Script {
         address organizer = vm.parseAddress(
             vm.prompt("Enter initial organizer address")
         );
+        address nftFallbackRecipient = vm.parseAddress(
+            vm.prompt(
+                "Enter address (with no code at account) which will be used as a fallback NFT recipient"
+            )
+        );
         address guideDAOToken = vm.parseAddress(
             vm.prompt("Enter GuideDAO token address")
         );
@@ -31,11 +36,18 @@ contract LotteryDeployScript is Script {
             vm.prompt("Enter Chainlink VRF subscription ID")
         );
 
-        run(organizer, guideDAOToken, vrfCoordinator, subscriptionId);
+        run(
+            organizer,
+            nftFallbackRecipient,
+            guideDAOToken,
+            vrfCoordinator,
+            subscriptionId
+        );
     }
 
     function run(
         address _organizer,
+        address _nftFallbackRecipient,
         address _guideDAOToken,
         address _vrfCoordinator,
         uint256 _subscriptionId
@@ -44,6 +56,7 @@ contract LotteryDeployScript is Script {
 
         Lottery lottery = new Lottery(
             _organizer,
+            _nftFallbackRecipient,
             _guideDAOToken,
             _vrfCoordinator,
             _subscriptionId
@@ -51,6 +64,6 @@ contract LotteryDeployScript is Script {
 
         vm.stopBroadcast();
 
-        console.log("Lottery contract deployed to: ", address(lottery));
+        console.log("Lottery contract deployed to:", address(lottery));
     }
 }

--- a/script/LotteryDeploy.s.sol
+++ b/script/LotteryDeploy.s.sol
@@ -17,25 +17,36 @@ import {VRFConsumerConfig, LotteryConfig} from "src/libraries/Configs.sol";
  */
 contract LotteryDeployScript is Script {
     function run() external {
+        address organizer = vm.parseAddress(
+            vm.prompt("Enter initial organizer address")
+        );
         address guideDAOToken = vm.parseAddress(
             vm.prompt("Enter GuideDAO token address")
         );
 
-        run(guideDAOToken);
+        address vrfCoordinator = vm.parseAddress(
+            vm.prompt("Enter Chainlink VRF coordinator address")
+        );
+        uint256 subscriptionId = vm.parseUint(
+            vm.prompt("Enter Chainlink VRF subscription ID")
+        );
+
+        run(organizer, guideDAOToken, vrfCoordinator, subscriptionId);
     }
 
-    function run(address guideDaoToken) public {
+    function run(
+        address _organizer,
+        address _guideDAOToken,
+        address _vrfCoordinator,
+        uint256 _subscriptionId
+    ) public {
         vm.startBroadcast();
 
         Lottery lottery = new Lottery(
-            LotteryConfig.ORGANIZER,
-            LotteryConfig.TICKET_PRICE,
-            guideDaoToken,
-            VRFConsumerConfig.VRF_COORDINATOR,
-            VRFConsumerConfig.SUBSCRIPTION_ID,
-            VRFConsumerConfig.KEY_HASH,
-            VRFConsumerConfig.CALLBACK_GAS_LIMIT,
-            VRFConsumerConfig.REQUEST_CONFIRMATIONS
+            _organizer,
+            _guideDAOToken,
+            _vrfCoordinator,
+            _subscriptionId
         );
 
         vm.stopBroadcast();

--- a/script/local/AddConsumer.s.sol
+++ b/script/local/AddConsumer.s.sol
@@ -23,20 +23,28 @@ contract AddConsumerScript is Script {
             vm.prompt("Enter lottery contract address")
         );
 
-        run(consumer);
+        address vrfCoordinator = vm.parseAddress(
+            vm.prompt("Enter Chainlink VRF coordinator address")
+        );
+        uint256 subscriptionId = vm.parseUint(
+            vm.prompt("Enter Chainlink VRF subscription ID")
+        );
+
+        run(consumer, subscriptionId, vrfCoordinator);
     }
 
-    function run(address consumer) public {
+    function run(
+        address _consumer,
+        uint256 _subscriptionId,
+        address _vrfCoordinator
+    ) public {
         vm.startBroadcast();
 
         VRFCoordinatorV2_5Mock vrfCoordinatorMock = VRFCoordinatorV2_5Mock(
-            VRFConsumerConfig.VRF_COORDINATOR
+            _vrfCoordinator
         );
 
-        vrfCoordinatorMock.addConsumer(
-            VRFConsumerConfig.SUBSCRIPTION_ID,
-            consumer
-        );
+        vrfCoordinatorMock.addConsumer(_subscriptionId, _consumer);
 
         vm.stopBroadcast();
 

--- a/script/local/FundSubscription.s.sol
+++ b/script/local/FundSubscription.s.sol
@@ -45,9 +45,9 @@ contract FundSubscriptionScript is Script {
 
         vm.stopBroadcast();
 
-        console.log("Active subscription id: ", subscriptionId);
+        console.log("Active subscription id:", subscriptionId);
         console.log(
-            "Current consumer balance in Juels (1e-18 LINK): ",
+            "Current consumer balance in Juels (1e-18 LINK):",
             balanceInLink
         );
     }

--- a/script/local/MocksDeploy.s.sol
+++ b/script/local/MocksDeploy.s.sol
@@ -34,9 +34,9 @@ contract MocksDeployScript is Script {
         vm.stopBroadcast();
 
         console.log(
-            "VRF coordinator mock deployed to: ",
+            "VRF coordinator mock deployed to:",
             address(vrfCoordinatorMock)
         );
-        console.log("GuideDAO token mock deployed to: ", address(tokenMock));
+        console.log("GuideDAO token mock deployed to:", address(tokenMock));
     }
 }

--- a/src/Lottery.sol
+++ b/src/Lottery.sol
@@ -221,9 +221,22 @@ contract Lottery is
     /**
      * @inheritdoc ILottery
      */
+    function totalTicketsCount() external view returns (uint256) {
+        return _state.totalTicketsCount;
+    }
+
+    /**
+     * @inheritdoc ILottery
+     */
+    function userTicketsCount(address _user) external view returns (uint256) {
+        return _userTicketsCount(_user);
+    }
+
+    /**
+     * @inheritdoc ILottery
+     */
     function isActualParticipant(address _user) external view returns (bool) {
-        return (_status() != Types.LotteryStatus.Closed &&
-            participantsInfo[lotteryNumber][_user].ticketsBought > 0);
+        return _userTicketsCount(_user) > 0;
     }
 
     /**
@@ -781,7 +794,7 @@ contract Lottery is
      *     / (Yes)  (No) \
      * WaitingForReveal  RegistrationEnded
      */
-    function _status() private view returns (Types.LotteryStatus) {
+    function _status() internal view returns (Types.LotteryStatus) {
         if (!_state.wasStarted) return Types.LotteryStatus.Closed;
         if (
             block.timestamp < _state.registrationEndTime &&
@@ -797,6 +810,14 @@ contract Lottery is
         } else {
             return Types.LotteryStatus.RegistrationEnded;
         }
+    }
+
+    function _userTicketsCount(address _user) internal view returns (uint256) {
+        return (
+            _status() == Types.LotteryStatus.Closed
+                ? 0
+                : participantsInfo[lotteryNumber][_user].ticketsBought
+        );
     }
 
     /**

--- a/src/Lottery.sol
+++ b/src/Lottery.sol
@@ -108,6 +108,8 @@ contract Lottery is
 
     LotteryState private _state;
 
+    uint256 public ticketPrice = LotteryConfig.INITIAL_TICKET_PRICE;
+
     /**
      * @notice Returns current lottery number.
      * If no one was started up to this moment, returns 0.
@@ -154,8 +156,6 @@ contract Lottery is
      * @dev Updated in {fulfillRandomWords}.
      */
     uint256 public organizerFunds;
-
-    uint256 public ticketPrice = LotteryConfig.INITIAL_TICKET_PRICE;
 
     address public lastWinner;
 

--- a/src/Lottery.sol
+++ b/src/Lottery.sol
@@ -338,6 +338,11 @@ contract Lottery is
             )
         );
 
+        require(
+            _encryptedContactDetails.length > 0,
+            ZeroLengthContactDetails()
+        );
+
         LotteryState storage state = _state;
 
         mapping(uint256 index => address)

--- a/src/Lottery.sol
+++ b/src/Lottery.sol
@@ -18,12 +18,7 @@ import {Types} from "./libraries/Types.sol";
 /**
  * @notice Main lottery contract.
  */
-contract Lottery is
-    ILottery,
-    ILotteryErrors,
-    VRFConsumerBaseV2Plus,
-    AccessControl
-{
+contract Lottery is ILottery, ILotteryErrors, VRFConsumerBaseV2Plus, AccessControl {
     /**
      * @notice Information about every lottery participant.
      * @dev `participantIndex` helps to map given participant address
@@ -64,17 +59,13 @@ contract Lottery is
     /* Chainlink VRF configuration (see VRFConsumerConfig in
      libraries/Configs.sol) */
     bytes32 private constant KEY_HASH = VRFConsumerConfig.KEY_HASH;
-    uint32 private constant CALLBACK_GAS_LIMIT =
-        VRFConsumerConfig.CALLBACK_GAS_LIMIT;
-    uint16 private constant REQUEST_CONFIRMATIONS =
-        VRFConsumerConfig.REQUEST_CONFIRMATIONS;
+    uint32 private constant CALLBACK_GAS_LIMIT = VRFConsumerConfig.CALLBACK_GAS_LIMIT;
+    uint16 private constant REQUEST_CONFIRMATIONS = VRFConsumerConfig.REQUEST_CONFIRMATIONS;
     uint256 private immutable SUBSCRIPTION_ID;
 
     /* Role name hashes for AccessControl */
-    bytes32 public constant LOTTERY_ORGANIZER_ROLE =
-        keccak256(abi.encode("LOTTERY_ORGANIZER_ROLE"));
-    bytes32 public constant LOTTERY_OPERATOR_ROLE =
-        keccak256(abi.encode("LOTTERY_OPERATOR_ROLE"));
+    bytes32 public constant LOTTERY_ORGANIZER_ROLE = keccak256(abi.encode("LOTTERY_ORGANIZER_ROLE"));
+    bytes32 public constant LOTTERY_OPERATOR_ROLE = keccak256(abi.encode("LOTTERY_OPERATOR_ROLE"));
 
     /**
      * @notice Number of lotteries that must pass after a certain one
@@ -88,14 +79,10 @@ contract Lottery is
     uint8 public constant MAX_PARTICIPANTS_TO_CLEAR = 40;
 
     /* Business logic values */
-    uint8 public constant TARGET_PARTICIPANTS_NUMBER =
-        LotteryConfig.TARGET_PARTICIPANTS_NUMBER;
-    uint16 public constant MAX_PARTICIPANTS_NUMBER =
-        LotteryConfig.MAX_PARTICIPANTS_NUMBER;
-    uint256 public constant REGISTRATION_DURATION =
-        LotteryConfig.REGISTRATION_DURATION;
-    uint256 public constant MAX_EXTENSION_TIME =
-        LotteryConfig.MAX_EXTENSION_TIME;
+    uint8 public constant TARGET_PARTICIPANTS_NUMBER = LotteryConfig.TARGET_PARTICIPANTS_NUMBER;
+    uint16 public constant MAX_PARTICIPANTS_NUMBER = LotteryConfig.MAX_PARTICIPANTS_NUMBER;
+    uint256 public constant REGISTRATION_DURATION = LotteryConfig.REGISTRATION_DURATION;
+    uint256 public constant MAX_EXTENSION_TIME = LotteryConfig.MAX_EXTENSION_TIME;
     uint256 public constant REFUND_WINDOW = LotteryConfig.REFUND_WINDOW;
 
     IGuideDAOToken public immutable GUIDE_DAO_TOKEN;
@@ -126,15 +113,13 @@ contract Lottery is
      * @notice Returns participant address from particular lottery by its number
      * and participant index.
      */
-    mapping(uint256 lotteryNumber => mapping(uint256 index => address))
-        public participants;
+    mapping(uint256 lotteryNumber => mapping(uint256 index => address)) public participants;
 
     /**
      * @notice Returns participant information from particular lottery by its number
      * and participant index.
      */
-    mapping(uint256 lotteryNumber => mapping(address user => ParticipantInfo))
-        public participantsInfo;
+    mapping(uint256 lotteryNumber => mapping(address user => ParticipantInfo)) public participantsInfo;
 
     /**
      * @notice Returns refund batch by its id.
@@ -170,20 +155,13 @@ contract Lottery is
      * participants and corresponding participantsInfo) has been cleared from storage,
      * from one index in {participants} to another.
      */
-    event LotteryDataCleared(
-        uint256 lotteryNumber,
-        uint256 fromParticipantIndex,
-        uint256 toParticipantIndex
-    );
+    event LotteryDataCleared(uint256 lotteryNumber, uint256 fromParticipantIndex, uint256 toParticipantIndex);
 
     /**
      * @notice Unable to clear data about lottery participants because
      * current lottery number is not sufficient.
      */
-    error TooEarlyToClearData(
-        uint256 receivedCurrentLotteryNumber,
-        uint256 minimumCurrentLotteryNumber
-    );
+    error TooEarlyToClearData(uint256 receivedCurrentLotteryNumber, uint256 minimumCurrentLotteryNumber);
 
     /**
      * @dev There is no data about participants of lottery
@@ -222,24 +200,19 @@ contract Lottery is
      * @inheritdoc ILottery
      */
     function isActualParticipant(address _user) external view returns (bool) {
-        return (_status() != Types.LotteryStatus.Closed &&
-            participantsInfo[lotteryNumber][_user].ticketsBought > 0);
+        return (_status() != Types.LotteryStatus.Closed && participantsInfo[lotteryNumber][_user].ticketsBought > 0);
     }
 
     /**
      * @inheritdoc ILottery
      */
-    function latestContactDetails(
-        address _user
-    ) external view returns (bytes memory) {
-        for (uint i = 0; i < LOTTERY_DATA_FRESHNESS_INTERVAL; i++) {
+    function latestContactDetails(address _user) external view returns (bytes memory) {
+        for (uint256 i = 0; i < LOTTERY_DATA_FRESHNESS_INTERVAL; i++) {
             uint256 currentLotteryNumber = lotteryNumber - i;
 
             require(currentLotteryNumber > 0, NoContactDetails(_user));
 
-            ParticipantInfo storage actualUserInfo = participantsInfo[
-                currentLotteryNumber
-            ][_user];
+            ParticipantInfo storage actualUserInfo = participantsInfo[currentLotteryNumber][_user];
 
             if (actualUserInfo.ticketsBought > 0) {
                 return actualUserInfo.encryptedContactDetails;
@@ -286,49 +259,31 @@ contract Lottery is
     /**
      * @inheritdoc ILottery
      */
-    function enter(
-        uint256 _ticketsAmount,
-        bytes calldata _encryptedContactDetails
-    ) external payable {
+    function enter(uint256 _ticketsAmount, bytes calldata _encryptedContactDetails) external payable {
         Types.LotteryStatus currentStatus = _status();
         require(
             currentStatus == Types.LotteryStatus.OpenedForRegistration,
-            IncorrectLotteryStatus(
-                currentStatus,
-                Types.LotteryStatus.OpenedForRegistration
-            )
+            IncorrectLotteryStatus(currentStatus, Types.LotteryStatus.OpenedForRegistration)
         );
 
         require(msg.sender.code.length == 0, HasCode(msg.sender));
 
-        require(
-            GUIDE_DAO_TOKEN.balanceOf(msg.sender) == 0,
-            AlreadyHasToken(msg.sender)
-        );
+        require(GUIDE_DAO_TOKEN.balanceOf(msg.sender) == 0, AlreadyHasToken(msg.sender));
 
-        mapping(address participant => ParticipantInfo)
-            storage actualParticipantsInfo = participantsInfo[lotteryNumber];
+        mapping(address participant => ParticipantInfo) storage actualParticipantsInfo = participantsInfo[lotteryNumber];
 
-        require(
-            actualParticipantsInfo[msg.sender].ticketsBought == 0,
-            AlreadyRegistered(msg.sender)
-        );
+        require(actualParticipantsInfo[msg.sender].ticketsBought == 0, AlreadyRegistered(msg.sender));
 
         require(_ticketsAmount > 0, ZeroTicketsRequested(msg.sender));
 
         require(
             msg.value == ticketPrice * _ticketsAmount,
-            IncorrectPaymentAmount(
-                msg.sender,
-                msg.value,
-                ticketPrice * _ticketsAmount
-            )
+            IncorrectPaymentAmount(msg.sender, msg.value, ticketPrice * _ticketsAmount)
         );
 
         LotteryState storage state = _state;
 
-        mapping(uint index => address)
-            storage actualParticipants = participants[lotteryNumber];
+        mapping(uint256 index => address) storage actualParticipants = participants[lotteryNumber];
 
         actualParticipants[state.participantsCount] = msg.sender;
 
@@ -350,25 +305,17 @@ contract Lottery is
         Types.LotteryStatus currentStatus = _status();
         require(
             currentStatus == Types.LotteryStatus.OpenedForRegistration,
-            IncorrectLotteryStatus(
-                currentStatus,
-                Types.LotteryStatus.OpenedForRegistration
-            )
+            IncorrectLotteryStatus(currentStatus, Types.LotteryStatus.OpenedForRegistration)
         );
 
-        mapping(address participant => ParticipantInfo)
-            storage actualParticipantsInfo = participantsInfo[lotteryNumber];
+        mapping(address participant => ParticipantInfo) storage actualParticipantsInfo = participantsInfo[lotteryNumber];
 
-        require(
-            actualParticipantsInfo[msg.sender].ticketsBought > 0,
-            HasNotRegistered(msg.sender)
-        );
+        require(actualParticipantsInfo[msg.sender].ticketsBought > 0, HasNotRegistered(msg.sender));
 
         require(_amount > 0, ZeroTicketsRequested(msg.sender));
 
         require(
-            msg.value == ticketPrice * _amount,
-            IncorrectPaymentAmount(msg.sender, msg.value, ticketPrice * _amount)
+            msg.value == ticketPrice * _amount, IncorrectPaymentAmount(msg.sender, msg.value, ticketPrice * _amount)
         );
 
         actualParticipantsInfo[msg.sender].ticketsBought += _amount;
@@ -385,24 +332,16 @@ contract Lottery is
         Types.LotteryStatus currentStatus = _status();
         require(
             currentStatus == Types.LotteryStatus.OpenedForRegistration,
-            IncorrectLotteryStatus(
-                currentStatus,
-                Types.LotteryStatus.OpenedForRegistration
-            )
+            IncorrectLotteryStatus(currentStatus, Types.LotteryStatus.OpenedForRegistration)
         );
 
         require(_amount > 0, ZeroTicketsRequested(msg.sender));
 
-        mapping(address participant => ParticipantInfo)
-            storage actualParticipantsInfo = participantsInfo[lotteryNumber];
+        mapping(address participant => ParticipantInfo) storage actualParticipantsInfo = participantsInfo[lotteryNumber];
 
         require(
             actualParticipantsInfo[msg.sender].ticketsBought >= _amount,
-            InsufficientTicketsNumber(
-                msg.sender,
-                actualParticipantsInfo[msg.sender].ticketsBought,
-                _amount
-            )
+            InsufficientTicketsNumber(msg.sender, actualParticipantsInfo[msg.sender].ticketsBought, _amount)
         );
 
         LotteryState storage state = _state;
@@ -412,20 +351,15 @@ contract Lottery is
         _state.totalTicketsCount -= _amount;
 
         if (actualParticipantsInfo[msg.sender].ticketsBought == 0) {
-            uint256 participantIndex = actualParticipantsInfo[msg.sender]
-                .participantIndex;
+            uint256 participantIndex = actualParticipantsInfo[msg.sender].participantIndex;
 
-            mapping(uint index => address)
-                storage actualParticipants = participants[lotteryNumber];
+            mapping(uint256 index => address) storage actualParticipants = participants[lotteryNumber];
 
             if (participantIndex != state.participantsCount - 1) {
-                actualParticipants[participantIndex] = actualParticipants[
-                    state.participantsCount - 1
-                ];
+                actualParticipants[participantIndex] = actualParticipants[state.participantsCount - 1];
 
                 address movedParticipant = actualParticipants[participantIndex];
-                actualParticipantsInfo[movedParticipant]
-                    .participantIndex = participantIndex;
+                actualParticipantsInfo[movedParticipant].participantIndex = participantIndex;
             }
 
             delete actualParticipants[--state.participantsCount];
@@ -433,7 +367,7 @@ contract Lottery is
 
         emit TicketsReturned(lotteryNumber, msg.sender, _amount);
 
-        (bool success, ) = msg.sender.call{value: ticketPrice * _amount}("");
+        (bool success,) = msg.sender.call{value: ticketPrice * _amount}("");
 
         require(success, WithdrawFailed(msg.sender));
     }
@@ -451,9 +385,7 @@ contract Lottery is
             RefundBatch storage batch = refundBatches[batchId];
 
             if (block.timestamp <= batch.refundAssignmentTime + REFUND_WINDOW) {
-                uint256 userBatchRefundBalance = batch.refundBalances[
-                    msg.sender
-                ];
+                uint256 userBatchRefundBalance = batch.refundBalances[msg.sender];
 
                 batch.refundBalances[msg.sender] = 0;
                 totalRefundAmount += userBatchRefundBalance;
@@ -467,7 +399,7 @@ contract Lottery is
 
         emit MoneyRefunded(msg.sender, totalRefundAmount);
 
-        (bool success, ) = msg.sender.call{value: totalRefundAmount}("");
+        (bool success,) = msg.sender.call{value: totalRefundAmount}("");
 
         require(success, WithdrawFailed(msg.sender));
     }
@@ -495,25 +427,17 @@ contract Lottery is
     /**
      * @inheritdoc ILottery
      */
-    function extendRegistrationTime(
-        uint256 _duration
-    ) external onlyRole(LOTTERY_OPERATOR_ROLE) {
+    function extendRegistrationTime(uint256 _duration) external onlyRole(LOTTERY_OPERATOR_ROLE) {
         Types.LotteryStatus currentStatus = _status();
         require(
             currentStatus == Types.LotteryStatus.OpenedForRegistration,
-            IncorrectLotteryStatus(
-                currentStatus,
-                Types.LotteryStatus.OpenedForRegistration
-            )
+            IncorrectLotteryStatus(currentStatus, Types.LotteryStatus.OpenedForRegistration)
         );
 
         LotteryState storage state = _state;
 
         uint256 desiredExtensionTime = state.totalExtensionTime + _duration;
-        require(
-            desiredExtensionTime <= MAX_EXTENSION_TIME,
-            ExtensionTooLong(desiredExtensionTime, MAX_EXTENSION_TIME)
-        );
+        require(desiredExtensionTime <= MAX_EXTENSION_TIME, ExtensionTooLong(desiredExtensionTime, MAX_EXTENSION_TIME));
 
         state.totalExtensionTime = desiredExtensionTime;
         state.registrationEndTime += _duration;
@@ -540,9 +464,7 @@ contract Lottery is
         for (uint256 i = 0; i < _state.participantsCount; i++) {
             address participant = participants[lotteryNumber][i];
 
-            uint256 userRefundBalance = participantsInfo[lotteryNumber][
-                participant
-            ].ticketsBought * ticketPrice;
+            uint256 userRefundBalance = participantsInfo[lotteryNumber][participant].ticketsBought * ticketPrice;
 
             batch.refundBalances[participant] += userRefundBalance;
             batch.totalUnclaimedFunds += userRefundBalance;
@@ -562,10 +484,7 @@ contract Lottery is
         Types.LotteryStatus currentStatus = _status();
         require(
             currentStatus == Types.LotteryStatus.RegistrationEnded,
-            IncorrectLotteryStatus(
-                currentStatus,
-                Types.LotteryStatus.RegistrationEnded
-            )
+            IncorrectLotteryStatus(currentStatus, Types.LotteryStatus.RegistrationEnded)
         );
 
         _state.waitingForOracleResponse = true;
@@ -577,9 +496,7 @@ contract Lottery is
                 requestConfirmations: REQUEST_CONFIRMATIONS,
                 callbackGasLimit: CALLBACK_GAS_LIMIT,
                 numWords: 1,
-                extraArgs: VRFV2PlusClient._argsToBytes(
-                    VRFV2PlusClient.ExtraArgsV1({nativePayment: false})
-                )
+                extraArgs: VRFV2PlusClient._argsToBytes(VRFV2PlusClient.ExtraArgsV1({nativePayment: false}))
             })
         );
 
@@ -598,12 +515,11 @@ contract Lottery is
      * lottery to be cleared is at least {LOTTERY_DATA_FRESHNESS_INTERVAL}
      * - There is some data to clear at the specified index.
      */
-    function clearLotteryData(
-        uint256 _lotteryNumberToClear,
-        uint256 _fromParticipantIndex
-    ) external onlyRole(LOTTERY_OPERATOR_ROLE) {
-        uint256 minimumCurrentLotteryNumber = _lotteryNumberToClear +
-            LOTTERY_DATA_FRESHNESS_INTERVAL;
+    function clearLotteryData(uint256 _lotteryNumberToClear, uint256 _fromParticipantIndex)
+        external
+        onlyRole(LOTTERY_OPERATOR_ROLE)
+    {
+        uint256 minimumCurrentLotteryNumber = _lotteryNumberToClear + LOTTERY_DATA_FRESHNESS_INTERVAL;
         require(
             lotteryNumber >= minimumCurrentLotteryNumber,
             TooEarlyToClearData(lotteryNumber, minimumCurrentLotteryNumber)
@@ -611,19 +527,12 @@ contract Lottery is
 
         uint8 clearedAmount;
 
-        mapping(uint256 index => address)
-            storage lotteryParticipants = participants[_lotteryNumberToClear];
+        mapping(uint256 index => address) storage lotteryParticipants = participants[_lotteryNumberToClear];
 
-        mapping(address participant => ParticipantInfo)
-            storage lotteryParticipantsInfo = participantsInfo[
-                _lotteryNumberToClear
-            ];
+        mapping(address participant => ParticipantInfo) storage lotteryParticipantsInfo =
+            participantsInfo[_lotteryNumberToClear];
 
-        for (
-            uint i = _fromParticipantIndex;
-            clearedAmount < MAX_PARTICIPANTS_TO_CLEAR;
-            i++
-        ) {
+        for (uint256 i = _fromParticipantIndex; clearedAmount < MAX_PARTICIPANTS_TO_CLEAR; i++) {
             address participant = lotteryParticipants[i];
 
             if (participant == address(0)) {
@@ -636,24 +545,15 @@ contract Lottery is
             clearedAmount++;
         }
 
-        require(
-            clearedAmount > 0,
-            NothingToClear(_lotteryNumberToClear, _fromParticipantIndex)
-        );
+        require(clearedAmount > 0, NothingToClear(_lotteryNumberToClear, _fromParticipantIndex));
 
-        emit LotteryDataCleared(
-            _lotteryNumberToClear,
-            _fromParticipantIndex,
-            _fromParticipantIndex + clearedAmount - 1
-        );
+        emit LotteryDataCleared(_lotteryNumberToClear, _fromParticipantIndex, _fromParticipantIndex + clearedAmount - 1);
     }
 
     /**
      * @inheritdoc ILottery
      */
-    function withdrawOrganizerFunds(
-        address _recipient
-    ) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
+    function withdrawOrganizerFunds(address _recipient) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
         uint256 fundsToWithdraw = organizerFunds;
 
         require(fundsToWithdraw > 0, ZeroOrganizerBalance());
@@ -662,7 +562,7 @@ contract Lottery is
 
         emit OrganizerFundsWithdrawn(fundsToWithdraw);
 
-        (bool success, ) = _recipient.call{value: fundsToWithdraw}("");
+        (bool success,) = _recipient.call{value: fundsToWithdraw}("");
 
         require(success, WithdrawFailed(_recipient));
     }
@@ -670,25 +570,20 @@ contract Lottery is
     /**
      * @inheritdoc ILottery
      */
-    function collectExpiredRefunds(
-        uint256 _batchId,
-        address _recipient
-    ) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
+    function collectExpiredRefunds(uint256 _batchId, address _recipient) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
         RefundBatch storage batch = refundBatches[_batchId];
 
         uint256 totalUnclaimedFunds = batch.totalUnclaimedFunds;
 
         require(
-            batch.refundAssignmentTime + REFUND_WINDOW < block.timestamp &&
-                totalUnclaimedFunds > 0,
-            NoExpiredRefunds()
+            batch.refundAssignmentTime + REFUND_WINDOW < block.timestamp && totalUnclaimedFunds > 0, NoExpiredRefunds()
         );
 
         batch.totalUnclaimedFunds = 0;
 
         emit ExpiredRefundsCollected(_batchId, totalUnclaimedFunds);
 
-        (bool success, ) = _recipient.call{value: totalUnclaimedFunds}("");
+        (bool success,) = _recipient.call{value: totalUnclaimedFunds}("");
 
         require(success, WithdrawFailed(_recipient));
     }
@@ -696,9 +591,7 @@ contract Lottery is
     /**
      * @inheritdoc ILottery
      */
-    function changeOrganizer(
-        address _newOrganizer
-    ) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
+    function changeOrganizer(address _newOrganizer) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
         _grantRole(LOTTERY_ORGANIZER_ROLE, _newOrganizer);
         _revokeRole(LOTTERY_ORGANIZER_ROLE, organizer);
 
@@ -709,22 +602,15 @@ contract Lottery is
     /**
      * @inheritdoc ILottery
      */
-    function changeNftFallbackRecipient(
-        address _newNftFallbackRecipient
-    ) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
-        emit NftFallbackRecipientChanged(
-            nftFallbackRecipient,
-            _newNftFallbackRecipient
-        );
+    function changeNftFallbackRecipient(address _newNftFallbackRecipient) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
+        emit NftFallbackRecipientChanged(nftFallbackRecipient, _newNftFallbackRecipient);
         _setNftFallbackRecipient(_newNftFallbackRecipient);
     }
 
     /**
      * @inheritdoc ILottery
      */
-    function setTicketPrice(
-        uint256 _newTicketPrice
-    ) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
+    function setTicketPrice(uint256 _newTicketPrice) external onlyRole(LOTTERY_ORGANIZER_ROLE) {
         Types.LotteryStatus currentStatus = _status();
         require(
             currentStatus == Types.LotteryStatus.Closed,
@@ -742,11 +628,11 @@ contract Lottery is
      * Chainlink oracle.
      */
     function fulfillRandomWords(
-        uint256 /* requestId */,
+        uint256,
+        /* requestId */
         uint256[] calldata randomWords
     ) internal virtual override {
-        uint256 winnerTicketId = (randomWords[0] % _state.totalTicketsCount) +
-            1;
+        uint256 winnerTicketId = (randomWords[0] % _state.totalTicketsCount) + 1;
         address winner = _findWinnerFromUsers(winnerTicketId);
 
         lastWinner = winner;
@@ -755,7 +641,8 @@ contract Lottery is
 
         delete _state;
 
-        try GUIDE_DAO_TOKEN.mintTo(winner) {} catch {
+        try GUIDE_DAO_TOKEN.mintTo(winner) {}
+        catch {
             GUIDE_DAO_TOKEN.mintTo(nftFallbackRecipient);
         }
 
@@ -782,12 +669,12 @@ contract Lottery is
      */
     function _status() private view returns (Types.LotteryStatus) {
         if (!_state.wasStarted) return Types.LotteryStatus.Closed;
-        if (
-            block.timestamp < _state.registrationEndTime &&
-            _state.participantsCount < MAX_PARTICIPANTS_NUMBER
-        ) return Types.LotteryStatus.OpenedForRegistration;
-        if (_state.participantsCount < TARGET_PARTICIPANTS_NUMBER)
+        if (block.timestamp < _state.registrationEndTime && _state.participantsCount < MAX_PARTICIPANTS_NUMBER) {
+            return Types.LotteryStatus.OpenedForRegistration;
+        }
+        if (_state.participantsCount < TARGET_PARTICIPANTS_NUMBER) {
             return Types.LotteryStatus.Invalid;
+        }
         if (_state.waitingForOracleResponse) {
             return Types.LotteryStatus.WaitingForReveal;
         } else {
@@ -800,15 +687,12 @@ contract Lottery is
      * @dev Returns NFT fallback recipient address, if total tickets amount is less than
      * winner ticket id, which should really never happen.
      */
-    function _findWinnerFromUsers(
-        uint256 _winnerTicketId
-    ) internal view returns (address) {
+    function _findWinnerFromUsers(uint256 _winnerTicketId) internal view returns (address) {
         uint256 cumulativeTickets = 0;
 
         for (uint256 i = 0; i < _state.participantsCount; i++) {
             address participant = participants[lotteryNumber][i];
-            cumulativeTickets += participantsInfo[lotteryNumber][participant]
-                .ticketsBought;
+            cumulativeTickets += participantsInfo[lotteryNumber][participant].ticketsBought;
 
             if (_winnerTicketId <= cumulativeTickets) {
                 return participant;
@@ -825,14 +709,8 @@ contract Lottery is
     }
 
     function _setNftFallbackRecipient(address _nftFallbackRecipient) internal {
-        require(
-            _nftFallbackRecipient != address(0),
-            ZeroNftFallbackRecipientAddress()
-        );
-        require(
-            _nftFallbackRecipient.code.length == 0,
-            HasCode(_nftFallbackRecipient)
-        );
+        require(_nftFallbackRecipient != address(0), ZeroNftFallbackRecipientAddress());
+        require(_nftFallbackRecipient.code.length == 0, HasCode(_nftFallbackRecipient));
 
         nftFallbackRecipient = _nftFallbackRecipient;
     }

--- a/src/interfaces/ILottery.sol
+++ b/src/interfaces/ILottery.sol
@@ -124,6 +124,18 @@ interface ILottery {
     function participantsCount() external view returns (uint256);
 
     /**
+     * @notice Returns total amount of tickets sold in current
+     * lottery. Returns zero if there is no such ongoing one.
+     */
+    function totalTicketsCount() external view returns (uint256);
+
+    /**
+     * @notice Returns amount of tickets bought by particular user in current
+     * lottery. Returns zero if there is no such ongoing one.
+     */
+    function userTicketsCount(address _user) external view returns (uint256);
+
+    /**
      * @notice Returns true only if the lottery is active and given user
      * is its participant.
      */
@@ -313,11 +325,8 @@ interface ILottery {
     function changeOrganizer(address _newOrganizer) external;
 
     /**
-     * @notice Change current organizer.
-     * @dev Revokes organizer role from current organizer
-     * and grants such to a new one.
-     *
-     * Emits {OrganizerChanged}.
+     * @notice Change current NFT fallback recipient.
+     * @dev Emits {NftFallbackRecipientChanged}.
      *
      * Requirements:
      * - Caller is current organizer

--- a/src/interfaces/ILottery.sol
+++ b/src/interfaces/ILottery.sol
@@ -193,6 +193,7 @@ interface ILottery {
      * - New total number of participants must not exceed the limit
      * - Registration is currently open
      * - The sent ether is sufficient to buy given tickets amount
+     * - `_encryptedContactDetails` length is not zero
      */
     function enter(
         uint256 _ticketsAmount,

--- a/src/interfaces/ILotteryErrors.sol
+++ b/src/interfaces/ILotteryErrors.sol
@@ -19,6 +19,11 @@ interface ILotteryErrors {
     error HasCode(address caller);
 
     /**
+     * @notice Attached contact details bytes array has zero length.
+     */
+    error ZeroLengthContactDetails();
+
+    /**
      * @notice The amount of ether sent is not enough or too large.
      */
     error IncorrectPaymentAmount(address sender, uint256 sent, uint256 needed);

--- a/src/interfaces/ILotteryErrors.sol
+++ b/src/interfaces/ILotteryErrors.sol
@@ -8,9 +8,20 @@ import {Types} from "../libraries/Types.sol";
  */
 interface ILotteryErrors {
     /**
-     * @notice The amount of ether sent is not enough.
+     * @notice There are no contact details about this particular user
+     * or they are stale.
      */
-    error InsufficientFunds(address sender, uint256 sent, uint256 needed);
+    error NoContactDetails(address user);
+
+    /**
+     * @notice `caller` account has code.
+     */
+    error HasCode(address caller);
+
+    /**
+     * @notice The amount of ether sent is not enough or too large.
+     */
+    error IncorrectPaymentAmount(address sender, uint256 sent, uint256 needed);
 
     /**
      * @notice The `participant` has already registered in the lottery.
@@ -26,12 +37,6 @@ interface ILotteryErrors {
      * @notice `caller` already has GuideDAO NFT.
      */
     error AlreadyHasToken(address caller);
-
-    /**
-     * @notice New user cannot enter the lottery, since participants
-     * limit has been already reached.
-     */
-    error ParticipantsLimitExceeded(uint limit);
 
     /**
      * @notice The `caller` has not entered the lottery before.
@@ -90,6 +95,11 @@ interface ILotteryErrors {
      * @notice Unable to change organizer address to zero.
      */
     error ZeroOrganizerAddress();
+
+    /**
+     * @notice Unable to change NFT fallback recipient address to zero.
+     */
+    error ZeroNftFallbackRecipientAddress();
 
     /**
      * @notice Unable to change ticket price to zero.

--- a/src/libraries/Configs.sol
+++ b/src/libraries/Configs.sol
@@ -32,8 +32,6 @@ library VRFCoordinatorMockConfig {
  * See details here: https://docs.chain.link/vrf/v2-5/overview/subscription
  */
 library VRFConsumerConfig {
-    address constant VRF_COORDINATOR = address(0);
-    uint256 constant SUBSCRIPTION_ID = 0;
     bytes32 constant KEY_HASH =
         0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
     uint32 constant CALLBACK_GAS_LIMIT = 1500000;
@@ -41,13 +39,14 @@ library VRFConsumerConfig {
 }
 
 /**
- * @dev Initial lottery configuration for deployment.
- *
- * If you are running locally, `ORGANIZER` (account that can collect
- * earned funds from lottery and expired refunds) can be directly set
- * to your address just for the sake of convenience.
+ * @dev Initial lottery configuration for deployment with
+ * essential business logic variables.
  */
 library LotteryConfig {
-    address constant ORGANIZER = 0x000000000000000000000000000000000000dEaD;
-    uint256 constant TICKET_PRICE = 0.03 ether;
+    uint256 constant INITIAL_TICKET_PRICE = 0.02 ether;
+    uint8 constant TARGET_PARTICIPANTS_NUMBER = 20;
+    uint16 constant MAX_PARTICIPANTS_NUMBER = 200;
+    uint256 constant REGISTRATION_DURATION = 21 days;
+    uint256 constant MAX_EXTENSION_TIME = 7 days;
+    uint256 constant REFUND_WINDOW = 14 days;
 }

--- a/src/libraries/Configs.sol
+++ b/src/libraries/Configs.sol
@@ -33,7 +33,7 @@ library VRFCoordinatorMockConfig {
  */
 library VRFConsumerConfig {
     bytes32 constant KEY_HASH =
-        0x787d74caea10b2b357790d5b5247c2f63d1d91572a9846f780606e4d953677ae;
+        0x1770bdc7eec7771f7ba4ffd640f34260d7f095b79c92d34a5b2551d6f6cfd2be;
     uint32 constant CALLBACK_GAS_LIMIT = 1500000;
     uint16 constant REQUEST_CONFIRMATIONS = 3;
 }
@@ -43,8 +43,8 @@ library VRFConsumerConfig {
  * essential business logic variables.
  */
 library LotteryConfig {
-    uint256 constant INITIAL_TICKET_PRICE = 0.02 ether;
-    uint8 constant TARGET_PARTICIPANTS_NUMBER = 20;
+    uint256 constant INITIAL_TICKET_PRICE = 0.000000001 ether;
+    uint8 constant TARGET_PARTICIPANTS_NUMBER = 2;
     uint16 constant MAX_PARTICIPANTS_NUMBER = 200;
     uint256 constant REGISTRATION_DURATION = 21 days;
     uint256 constant MAX_EXTENSION_TIME = 7 days;

--- a/test/Lottery.t.sol
+++ b/test/Lottery.t.sol
@@ -5,26 +5,39 @@ import {Test, console} from "forge-std/Test.sol";
 
 import {VRFCoordinatorV2_5Mock} from "@chainlink/contracts/src/v0.8/vrf/mocks/VRFCoordinatorV2_5Mock.sol";
 
-import {Lottery} from "src/Lottery.sol";
+import {ILottery} from "src/interfaces/ILottery.sol";
 import {ILotteryErrors} from "src/interfaces/ILotteryErrors.sol";
+import {Lottery} from "src/Lottery.sol";
 
 import {GuideDAOTokenMock} from "./mocks/GuideDAOTokenMock.sol";
+import {NonPayable} from "./mocks/NonPayable.sol";
 
 import {VRFCoordinatorMockConfig, VRFConsumerConfig, LotteryConfig} from "src/libraries/Configs.sol";
 
 import {Types} from "src/libraries/Types.sol";
 
 contract LotteryTest is Test {
+    /* Contract without receive() function */
+    NonPayable nonPayable;
+
     VRFCoordinatorV2_5Mock vrfCoordinator;
     GuideDAOTokenMock guideDAOToken;
 
-    address[200] participants;
+    address nftFallbackRecipient = makeAddr("nftFallbackRecipient");
+
+    address[] participants;
 
     Lottery lottery;
 
+    /* receive() function to withdraw funds from successful lotteries
+    and expired refunds for the sake of convenience. */
+    receive() external payable {}
+
     function setUp() external {
-        for (uint i = 0; i < 200; i++) {
-            participants[i] = vm.addr(i + 1);
+        nonPayable = new NonPayable();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER; i++) {
+            participants.push(vm.addr(i + 1));
         }
 
         vrfCoordinator = new VRFCoordinatorV2_5Mock(
@@ -34,23 +47,1797 @@ contract LotteryTest is Test {
         );
 
         uint256 subscriptionId = vrfCoordinator.createSubscription();
-        vrfCoordinator.fundSubscription(subscriptionId, 100000000000000000000);
+        vrfCoordinator.fundSubscription(subscriptionId, 10e22);
 
         guideDAOToken = new GuideDAOTokenMock();
 
         lottery = new Lottery(
-            LotteryConfig.ORGANIZER,
-            LotteryConfig.TICKET_PRICE,
+            address(this),
+            nftFallbackRecipient,
             address(guideDAOToken),
             address(vrfCoordinator),
-            subscriptionId,
-            VRFConsumerConfig.KEY_HASH,
-            VRFConsumerConfig.CALLBACK_GAS_LIMIT,
-            VRFConsumerConfig.REQUEST_CONFIRMATIONS
+            subscriptionId
         );
+
+        lottery.grantRole(lottery.LOTTERY_OPERATOR_ROLE(), address(this));
 
         vrfCoordinator.addConsumer(subscriptionId, address(lottery));
 
         guideDAOToken.setIsAdmin(address(lottery), true);
+    }
+
+    function test_start_AllowsToStart() external {
+        vm.assertTrue(lottery.status() == Types.LotteryStatus.Closed);
+
+        vm.expectEmit();
+        emit ILottery.LotteryStarted(1, block.timestamp);
+
+        lottery.start();
+
+        vm.assertTrue(
+            lottery.status() == Types.LotteryStatus.OpenedForRegistration
+        );
+        vm.assertEq(
+            lottery.registrationEndTime(),
+            block.timestamp + lottery.REGISTRATION_DURATION()
+        );
+    }
+
+    function test_start_RevertsIfTryingToStartActiveLottery() external {
+        lottery.start();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.OpenedForRegistration,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.RegistrationEnded,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.start();
+
+        lottery.requestWinner();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.WaitingForReveal,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.start();
+    }
+
+    function test_start_RevertsIfTryingToStartAfterLotteryHasBeenConsideredInvalid()
+        external
+    {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Invalid,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.start();
+    }
+
+    function test_extendRegistrationTime_AllowsToExtend() external {
+        lottery.start();
+
+        vm.expectEmit();
+        emit ILottery.RegistrationTimeExtended(1, 3600);
+
+        lottery.extendRegistrationTime(3600);
+
+        uint256 maxExtensionTime = lottery.MAX_EXTENSION_TIME();
+
+        vm.expectEmit();
+        emit ILottery.RegistrationTimeExtended(1, maxExtensionTime - 3600);
+
+        lottery.extendRegistrationTime(maxExtensionTime - 3600);
+    }
+
+    function test_extendRegistrationTime_RevertsIfTryingToExtendLotteryNotDuringRegistration()
+        external
+    {
+        uint256 extensionTime = lottery.MAX_EXTENSION_TIME();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Closed,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        lottery.extendRegistrationTime(extensionTime);
+
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.RegistrationEnded,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        lottery.extendRegistrationTime(extensionTime);
+
+        lottery.requestWinner();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.WaitingForReveal,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        lottery.extendRegistrationTime(extensionTime);
+    }
+
+    function test_extendRegistrationTime_RevertsIfTryingToExtendAfterLotteryHasBeenConsideredInvalid()
+        external
+    {
+        uint256 extensionTime = lottery.MAX_EXTENSION_TIME();
+
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Invalid,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        lottery.extendRegistrationTime(extensionTime);
+    }
+
+    function test_extendRegistrationTime_RevertsIfExtensionTooLong() external {
+        lottery.start();
+
+        uint256 maxExtensionTime = lottery.MAX_EXTENSION_TIME();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ExtensionTooLong.selector,
+                maxExtensionTime + 1,
+                maxExtensionTime
+            )
+        );
+        lottery.extendRegistrationTime(maxExtensionTime + 1);
+    }
+
+    function test_enter_AllowsToEnter() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER - 1; i++) {
+            hoax(participants[i]);
+
+            vm.expectEmit();
+            emit ILottery.TicketsBought(1, participants[i], 1);
+
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.assertEq(
+            lottery.participantsCount(),
+            LotteryConfig.MAX_PARTICIPANTS_NUMBER - 1
+        );
+        vm.assertTrue(
+            lottery.status() == Types.LotteryStatus.OpenedForRegistration
+        );
+
+        for (uint i = 0; i < lottery.participantsCount(); i++) {
+            vm.assertTrue(lottery.isActualParticipant(participants[i]));
+        }
+    }
+
+    function test_enter_ClosesRegistrationAfterReachingMaxParticipantsNumber()
+        external
+    {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+            (uint256 ticketsBought, , ) = lottery.participantsInfo(
+                lottery.lotteryNumber(),
+                participants[i]
+            );
+
+            vm.assertEq(ticketsBought, 1);
+        }
+
+        vm.assertEq(
+            lottery.participantsCount(),
+            LotteryConfig.MAX_PARTICIPANTS_NUMBER
+        );
+        vm.assertTrue(
+            lottery.status() == Types.LotteryStatus.RegistrationEnded
+        );
+    }
+
+    function test_enter_RevertsIfTryingToEnterNotDuringRegistration() external {
+        address participant = makeAddr("participant");
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Closed,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        lottery.start();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.requestWinner();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.WaitingForReveal,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+    }
+
+    function test_enter_RevertsIfTryingToEnterAfterLotteryHasBeenConsideredInvalid()
+        external
+    {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Invalid,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+    }
+
+    function test_enter_RevertsIfUserAccountHasCode() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.HasCode.selector,
+                /* Using this contract for simplicity */
+                address(this)
+            )
+        );
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+    }
+
+    function test_enter_RevertsIfUserAlreadyHasToken() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        guideDAOToken.mintTo(participant);
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.AlreadyHasToken.selector,
+                participant
+            )
+        );
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+    }
+
+    function test_enter_RevertsIfTryingToEnterTwice() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        startHoax(participant);
+
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.AlreadyRegistered.selector,
+                participant
+            )
+        );
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+    }
+
+    function test_enter_RevertsIfTryingToBuyZeroTickets() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ZeroTicketsRequested.selector,
+                participant
+            )
+        );
+        vm.prank(participant);
+        lottery.enter(0, "@somecontactdetails");
+    }
+
+    function test_enter_RevertsIfPaymentAmountIsIncorrect() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        uint256 insufficientPaymentAmount = 2 * ticketPrice;
+        uint256 correctPaymentAmount = 3 * ticketPrice;
+        uint256 exceedingPaymentAmount = 4 * ticketPrice;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectPaymentAmount.selector,
+                participant,
+                insufficientPaymentAmount,
+                correctPaymentAmount
+            )
+        );
+        hoax(participant);
+        lottery.enter{value: insufficientPaymentAmount}(
+            3,
+            "@somecontactdetails"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectPaymentAmount.selector,
+                participant,
+                exceedingPaymentAmount,
+                correctPaymentAmount
+            )
+        );
+        hoax(participant);
+        lottery.enter{value: exceedingPaymentAmount}(3, "@somecontactdetails");
+    }
+
+    function test_buyMoreTickets_AllowsToBuyMoreTickets() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.startPrank(participant);
+        vm.deal(participant, ticketPrice * 3);
+
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.expectEmit();
+        emit ILottery.TicketsBought(1, participant, 2);
+
+        lottery.buyMoreTickets{value: ticketPrice * 2}(2);
+
+        vm.stopPrank();
+
+        (uint256 ticketsBought, , ) = lottery.participantsInfo(
+            lottery.lotteryNumber(),
+            participant
+        );
+
+        vm.assertEq(ticketsBought, 3);
+    }
+
+    function test_buyMoreTickets_RevertsIfTryingToBuyNotDuringRegistration()
+        external
+    {
+        address participant = makeAddr("participant");
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Closed,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        hoax(participant);
+        lottery.buyMoreTickets{value: ticketPrice}(1);
+
+        lottery.start();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.requestWinner();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.WaitingForReveal,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        hoax(participant);
+        lottery.buyMoreTickets{value: ticketPrice}(1);
+    }
+
+    function test_buyMoreTickets_RevertsIfTryingToBuyTicketsAfterLotteryHasBeenConsideredInvalid()
+        external
+    {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Invalid,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        hoax(participant);
+        lottery.buyMoreTickets{value: ticketPrice}(1);
+    }
+
+    function test_buyMoreTickets_RevertsIfTryingToBuyMoreTicketsBeforeEnter()
+        external
+    {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.HasNotRegistered.selector,
+                participant
+            )
+        );
+        hoax(participant);
+        lottery.buyMoreTickets{value: ticketPrice}(1);
+    }
+
+    function test_buyMoreTickets_RevertsIfTryingToBuyZeroTickets() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint ticketPrice = lottery.ticketPrice();
+
+        startHoax(participant);
+
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ZeroTicketsRequested.selector,
+                participant
+            )
+        );
+        lottery.buyMoreTickets(0);
+    }
+
+    function test_buyMoreTickets_RevertsIfPaymentAmountIsIncorrect() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        uint256 insufficientPaymentAmount = 2 * ticketPrice;
+        uint256 correctPaymentAmount = 3 * ticketPrice;
+        uint256 exceedingPaymentAmount = 4 * ticketPrice;
+
+        startHoax(participant);
+
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectPaymentAmount.selector,
+                participant,
+                insufficientPaymentAmount,
+                correctPaymentAmount
+            )
+        );
+        lottery.buyMoreTickets{value: insufficientPaymentAmount}(3);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectPaymentAmount.selector,
+                participant,
+                exceedingPaymentAmount,
+                correctPaymentAmount
+            )
+        );
+        lottery.buyMoreTickets{value: exceedingPaymentAmount}(3);
+    }
+
+    function test_returnTickets_AllowsToPartiallyReturn() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.startPrank(participant);
+        vm.deal(participant, ticketPrice * 2);
+
+        lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+
+        vm.expectEmit();
+        emit ILottery.TicketsReturned(1, participant, 1);
+
+        lottery.returnTickets(1);
+
+        vm.stopPrank();
+
+        (uint256 ticketsBought, , ) = lottery.participantsInfo(
+            lottery.lotteryNumber(),
+            participant
+        );
+
+        vm.assertEq(participant.balance, ticketPrice);
+        vm.assertTrue(lottery.isActualParticipant(participant));
+        vm.assertEq(ticketsBought, 1);
+
+        vm.assertEq(lottery.participantsCount(), 1);
+    }
+
+    function test_returnTickets_AllowsToFullyReturnIfUserIsLast() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.startPrank(participant);
+        vm.deal(participant, ticketPrice);
+
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.expectEmit();
+        emit ILottery.TicketsReturned(1, participant, 1);
+
+        lottery.returnTickets(1);
+
+        vm.stopPrank();
+
+        vm.assertEq(participant.balance, ticketPrice);
+        vm.assertFalse(lottery.isActualParticipant(participant));
+
+        vm.assertEq(lottery.participantsCount(), 0);
+    }
+
+    function test_returnTickets_AllowsToFullyReturnIfUserIsNotLast() external {
+        lottery.start();
+
+        address firstParticipant = participants[0];
+        address secondParticipant = participants[1];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.deal(firstParticipant, ticketPrice);
+        vm.prank(firstParticipant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        hoax(secondParticipant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.prank(firstParticipant);
+
+        vm.expectEmit();
+        emit ILottery.TicketsReturned(1, firstParticipant, 1);
+
+        lottery.returnTickets(1);
+
+        (uint256 ticketsBought, uint256 index, ) = lottery.participantsInfo(
+            lottery.lotteryNumber(),
+            secondParticipant
+        );
+
+        vm.assertEq(ticketsBought, 1);
+        vm.assertEq(index, 0);
+        vm.assertTrue(lottery.isActualParticipant(secondParticipant));
+
+        vm.assertEq(firstParticipant.balance, ticketPrice);
+        vm.assertFalse(lottery.isActualParticipant(firstParticipant));
+
+        vm.assertEq(lottery.participantsCount(), 1);
+    }
+
+    function test_returnTickets_RevertsIfTryingToReturnNotDuringRegistration()
+        external
+    {
+        address participant = makeAddr("participant");
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Closed,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        vm.prank(participant);
+        lottery.returnTickets(1);
+
+        lottery.start();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.requestWinner();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.WaitingForReveal,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        vm.prank(participant);
+        lottery.returnTickets(1);
+    }
+
+    function test_returnTickets_RevertsIfTryingToReturnTicketsAfterLotteryHasBeenConsideredInvalid()
+        external
+    {
+        address participant = participants[0];
+
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Invalid,
+                Types.LotteryStatus.OpenedForRegistration
+            )
+        );
+        vm.prank(participant);
+        lottery.returnTickets(1);
+    }
+
+    function test_returnTickets_RevertsIfTryingToReturnZeroTickets() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ZeroTicketsRequested.selector,
+                participant
+            )
+        );
+        vm.prank(participant);
+        lottery.returnTickets(0);
+    }
+
+    function test_returnTickets_RevertsIfTryingToReturnBeforeEnter() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 wantToReturn = 1;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.InsufficientTicketsNumber.selector,
+                participant,
+                0,
+                wantToReturn
+            )
+        );
+        vm.prank(participant);
+        lottery.returnTickets(wantToReturn);
+    }
+
+    function test_returnTickets_RevertsIfTryingToReturnMoreThanBought()
+        external
+    {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        uint256 wantToBuy = 3;
+        uint256 wantToReturn = 4;
+
+        hoax(participant);
+        lottery.enter{value: wantToBuy * ticketPrice}(
+            wantToBuy,
+            "@somecontactdetails"
+        );
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.InsufficientTicketsNumber.selector,
+                participant,
+                wantToBuy,
+                wantToReturn
+            )
+        );
+        vm.prank(participant);
+        lottery.returnTickets(wantToReturn);
+    }
+
+    function test_returnTickets_RevertsIfTryingToWithdrawToNonPayable()
+        external
+    {
+        lottery.start();
+
+        (address participant, uint256 privateKey) = makeAddrAndKey(
+            "participant"
+        );
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        uint256 wantToBuy = 2;
+        uint256 wantToReturn = 1;
+
+        startHoax(participant);
+
+        lottery.enter{value: wantToBuy * ticketPrice}(
+            wantToBuy,
+            "@somecontactdetails"
+        );
+
+        vm.signAndAttachDelegation(address(nonPayable), privateKey);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.WithdrawFailed.selector,
+                participant
+            )
+        );
+        lottery.returnTickets(wantToReturn);
+    }
+
+    function test_requestWinner_AllowsToRequest() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.expectEmit();
+        emit ILottery.WinnerRequested(1, 1, block.timestamp);
+
+        lottery.requestWinner();
+
+        assertTrue(lottery.status() == Types.LotteryStatus.WaitingForReveal);
+    }
+
+    function test_requestWinner_RevertsIfTryingToRequestWinnerBeforeRegistrationEnd()
+        external
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Closed,
+                Types.LotteryStatus.RegistrationEnded
+            )
+        );
+        lottery.requestWinner();
+
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.OpenedForRegistration,
+                Types.LotteryStatus.RegistrationEnded
+            )
+        );
+        lottery.requestWinner();
+    }
+
+    function test_requestWinner_RevertsIfTryingToRequestWinnerAfterLotteryHasBeenConsideredInvalid()
+        external
+    {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Invalid,
+                Types.LotteryStatus.RegistrationEnded
+            )
+        );
+        lottery.requestWinner();
+    }
+
+    function test_fulfillRandomWords_AllowsToRevealWinnerAndGrantPrize()
+        external
+    {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        lottery.requestWinner();
+
+        /* We do not check second topic since we assume that we
+            do not know winner address yet. However, in this test case
+            it is determenistic and we could use hard-coded value as well,
+            but current approach is more suitable for possible changes,
+            and we still require that winner do recieve their prize NFT. */
+        vm.expectEmit(true, false, true, true);
+        emit ILottery.WinnerRevealed(1, address(0), block.timestamp);
+
+        vrfCoordinator.fulfillRandomWords(1, address(lottery));
+
+        vm.assertTrue(lottery.status() == Types.LotteryStatus.Closed);
+
+        address lastWinner = lottery.lastWinner();
+
+        vm.assertNotEq(lastWinner, address(0));
+        vm.assertNotEq(lastWinner, lottery.nftFallbackRecipient());
+        vm.assertNotEq(lastWinner, lottery.organizer());
+
+        vm.assertEq(guideDAOToken.balanceOf(lastWinner), 1);
+        vm.assertEq(
+            lottery.latestContactDetails(lastWinner),
+            "@somecontactdetails"
+        );
+    }
+
+    /* This test handles possible edge case: despite the fact that we
+    check code length at user account when they buy tickets for the first time,
+    EIP-7702 made it possible to attach delegation to smart contract whenever
+    they want, so we cannot rely only on that check alone.  */
+    function test_fulfillRandomWords_MintsTokenToFallbackRecipientIfWinnerHasCode()
+        external
+    {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER; i++) {
+            /* Re-creating participants from private keys for clarity */
+            address participant = vm.addr(i + 1);
+
+            hoax(participant);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+            /* For simplicity, let them all sign and attach delegation to
+            some smart contract. */
+            vm.signAndAttachDelegation(address(nonPayable), i + 1);
+        }
+
+        lottery.requestWinner();
+        vrfCoordinator.fulfillRandomWords(1, address(lottery));
+
+        address lastWinner = lottery.lastWinner();
+
+        vm.assertNotEq(lastWinner, address(0));
+        vm.assertNotEq(lastWinner, nftFallbackRecipient);
+        vm.assertNotEq(lastWinner, lottery.organizer());
+
+        vm.assertEq(guideDAOToken.balanceOf(nftFallbackRecipient), 1);
+        vm.assertEq(
+            lottery.latestContactDetails(lastWinner),
+            "@somecontactdetails"
+        );
+    }
+
+    function test_closeInvalidLottery_AllowsToCorrectlyClose() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (
+            uint i = 0;
+            i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1;
+            i++
+        ) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.assertTrue(lottery.status() == Types.LotteryStatus.Invalid);
+
+        vm.expectEmit();
+        emit ILottery.InvalidLotteryClosed(1, block.timestamp);
+
+        uint256 expectedBatchId = lottery.nextRefundBatchId();
+        lottery.closeInvalidLottery();
+
+        vm.assertTrue(lottery.status() == Types.LotteryStatus.Closed);
+        vm.assertEq(lottery.nextRefundBatchId(), expectedBatchId + 1);
+
+        (uint256 refundAssignmentTime, uint256 totalUnclaimedFunds) = lottery
+            .refundBatches(expectedBatchId);
+
+        vm.assertEq(refundAssignmentTime, block.timestamp);
+        vm.assertEq(
+            totalUnclaimedFunds,
+            (LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1) * ticketPrice
+        );
+
+        for (
+            uint i = 0;
+            i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1;
+            i++
+        ) {
+            vm.assertEq(lottery.refundAmount(participants[i]), ticketPrice);
+        }
+    }
+
+    function test_closeInvalidLottery_RevertsIfTryingToCloseLotteryThatIsNotInvalid()
+        external
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Closed,
+                Types.LotteryStatus.Invalid
+            )
+        );
+        lottery.closeInvalidLottery();
+
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.RegistrationEnded,
+                Types.LotteryStatus.Invalid
+            )
+        );
+        lottery.closeInvalidLottery();
+
+        lottery.requestWinner();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.WaitingForReveal,
+                Types.LotteryStatus.Invalid
+            )
+        );
+        lottery.closeInvalidLottery();
+    }
+
+    function test_clearLotteryData_AllowsToClear() external {
+        uint256 maxParticipantsToClear = lottery.MAX_PARTICIPANTS_TO_CLEAR();
+
+        /* Necessary to keep in order to avoid situations when user with
+        GuideDAO NFT (i.e. one of the previous winners) tries to enter the new lottery. */
+        uint256 totalParticipantsCount;
+        for (uint i = 0; i < 6; i++) {
+            lottery.start();
+
+            uint256 ticketPrice = lottery.ticketPrice();
+
+            uint256 participantsAmount = i == 0
+                ? maxParticipantsToClear * 2
+                : LotteryConfig.TARGET_PARTICIPANTS_NUMBER;
+
+            for (uint j = 0; j < participantsAmount; j++) {
+                address participant = participants[j + totalParticipantsCount];
+
+                hoax(participant);
+                lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+            }
+
+            totalParticipantsCount += participantsAmount;
+
+            vm.warp(lottery.registrationEndTime());
+
+            lottery.requestWinner();
+            vrfCoordinator.fulfillRandomWords(i + 1, address(lottery));
+        }
+
+        vm.expectEmit();
+        emit Lottery.LotteryDataCleared(1, 0, maxParticipantsToClear - 1);
+
+        lottery.clearLotteryData(1, 0);
+
+        vm.expectEmit();
+        emit Lottery.LotteryDataCleared(
+            1,
+            maxParticipantsToClear,
+            maxParticipantsToClear * 2 - 1
+        );
+
+        lottery.clearLotteryData(1, maxParticipantsToClear);
+
+        for (uint i = 0; i < maxParticipantsToClear * 2; i++) {
+            address participant = lottery.participants(1, i);
+            assertEq(participant, address(0));
+
+            (
+                uint256 ticketsBought,
+                uint256 participantIndex,
+                bytes memory contactDetails
+            ) = lottery.participantsInfo(0, participants[i]);
+
+            assertEq(ticketsBought, 0);
+            assertEq(participantIndex, 0);
+            assertEq(contactDetails, "");
+        }
+    }
+
+    function test_clearLotteryData_RevertsIfTryingToCleanRecentData() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.requestWinner();
+        vrfCoordinator.fulfillRandomWords(1, address(lottery));
+
+        uint256 lotteryNumber = lottery.lotteryNumber();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Lottery.TooEarlyToClearData.selector,
+                lottery.lotteryNumber(),
+                lottery.lotteryNumber() +
+                    lottery.LOTTERY_DATA_FRESHNESS_INTERVAL()
+            )
+        );
+        lottery.clearLotteryData(lotteryNumber, 0);
+    }
+
+    function test_clearLotteryData_RevertsIfNothingToClear() external {
+        for (uint i = 0; i < 6; i++) {
+            lottery.start();
+
+            uint256 ticketPrice = lottery.ticketPrice();
+
+            uint256 participantsOffset = i *
+                LotteryConfig.TARGET_PARTICIPANTS_NUMBER;
+
+            for (
+                uint j = 0;
+                j < LotteryConfig.TARGET_PARTICIPANTS_NUMBER;
+                j++
+            ) {
+                address participant = vm.addr(j + participantsOffset + 1);
+
+                hoax(participant);
+                lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+            }
+
+            vm.warp(lottery.registrationEndTime());
+
+            lottery.requestWinner();
+            vrfCoordinator.fulfillRandomWords(i + 1, address(lottery));
+        }
+
+        lottery.clearLotteryData(1, 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Lottery.NothingToClear.selector, 1, 0)
+        );
+        lottery.clearLotteryData(1, 0);
+    }
+
+    function test_refund_AllowsToRefund() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (
+            uint i = 0;
+            i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1;
+            i++
+        ) {
+            vm.deal(participants[i], ticketPrice * 2);
+            vm.prank(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        uint256 expectedBatchId = lottery.nextRefundBatchId();
+
+        lottery.closeInvalidLottery();
+
+        for (
+            uint i = 0;
+            i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1;
+            i++
+        ) {
+            (, uint256 totalUnclaimedBeforeRefund) = lottery.refundBatches(
+                expectedBatchId
+            );
+            uint256 userRefundAmount = lottery.refundAmount(participants[i]);
+
+            vm.assertEq(userRefundAmount, 2 * ticketPrice);
+
+            vm.expectEmit();
+            emit ILottery.MoneyRefunded(participants[i], 2 * ticketPrice);
+
+            vm.prank(participants[i]);
+            lottery.refund();
+
+            (, uint256 totalUnclaimedAfterRefund) = lottery.refundBatches(
+                expectedBatchId
+            );
+
+            vm.assertEq(participants[i].balance, userRefundAmount);
+            vm.assertEq(lottery.refundAmount(participants[i]), 0);
+            vm.assertEq(
+                totalUnclaimedAfterRefund,
+                totalUnclaimedBeforeRefund - userRefundAmount
+            );
+        }
+
+        (, uint256 totalUnclaimedBeforeAllRefunds) = lottery.refundBatches(
+            expectedBatchId
+        );
+
+        vm.assertEq(totalUnclaimedBeforeAllRefunds, 0);
+    }
+
+    function test_refund_RevertsIfNothingToRefund() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ZeroRefundBalance.selector,
+                participant
+            )
+        );
+        vm.prank(participant);
+        lottery.refund();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            vm.deal(participants[i], ticketPrice * 2);
+            vm.prank(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.requestWinner();
+        vrfCoordinator.fulfillRandomWords(1, address(lottery));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ZeroRefundBalance.selector,
+                participant
+            )
+        );
+        vm.prank(participant);
+        lottery.refund();
+    }
+
+    function test_refund_RevertsIfTryingToWithdrawToNonPayable() external {
+        lottery.start();
+
+        (address participant, uint256 privateKey) = makeAddrAndKey(
+            "participant"
+        );
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.signAndAttachDelegation(address(nonPayable), privateKey);
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.closeInvalidLottery();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.WithdrawFailed.selector,
+                participant
+            )
+        );
+        vm.prank(participant);
+        lottery.refund();
+    }
+
+    function test_collectExpiredRefunds_AllowsToCollect() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (
+            uint i = 0;
+            i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1;
+            i++
+        ) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        uint256 expectedBatchId = lottery.nextRefundBatchId();
+
+        lottery.closeInvalidLottery();
+
+        vm.warp(block.timestamp + lottery.REFUND_WINDOW() + 1);
+
+        uint balanceBeforeCollection = address(this).balance;
+
+        vm.expectEmit();
+        emit ILottery.ExpiredRefundsCollected(
+            expectedBatchId,
+            2 * ticketPrice * (LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1)
+        );
+
+        lottery.collectExpiredRefunds(expectedBatchId, address(this));
+
+        uint balanceAfterCollection = address(this).balance;
+
+        vm.assertEq(
+            balanceAfterCollection,
+            balanceBeforeCollection +
+                2 *
+                ticketPrice *
+                (LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1)
+        );
+    }
+
+    function test_collectExpiredRefunds_RevertsIfTryingToWithdrawToNonPayable()
+        external
+    {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (
+            uint i = 0;
+            i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1;
+            i++
+        ) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        uint256 expectedBatchId = lottery.nextRefundBatchId();
+
+        lottery.closeInvalidLottery();
+
+        vm.warp(block.timestamp + lottery.REFUND_WINDOW() + 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.WithdrawFailed.selector,
+                address(nonPayable)
+            )
+        );
+        lottery.collectExpiredRefunds(expectedBatchId, address(nonPayable));
+    }
+
+    function test_collectExpiredRefunds_RevertsIfRefundsNotExpired() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (
+            uint i = 0;
+            i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER - 1;
+            i++
+        ) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        uint256 expectedBatchId = lottery.nextRefundBatchId();
+
+        lottery.closeInvalidLottery();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ILotteryErrors.NoExpiredRefunds.selector)
+        );
+        lottery.collectExpiredRefunds(expectedBatchId, address(this));
+    }
+
+    function test_collectExpiredRefunds_RevertsIfNothingToRefund() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        uint256 expectedBatchId = lottery.nextRefundBatchId();
+
+        lottery.requestWinner();
+        vrfCoordinator.fulfillRandomWords(1, address(lottery));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(ILotteryErrors.NoExpiredRefunds.selector)
+        );
+        lottery.collectExpiredRefunds(expectedBatchId, address(this));
+    }
+
+    function test_withdrawOrganizerFunds_AllowToWithdrawFunds() external {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        lottery.requestWinner();
+
+        vrfCoordinator.fulfillRandomWords(1, address(lottery));
+
+        uint256 accessibleFunds = lottery.organizerFunds();
+
+        vm.assertEq(
+            accessibleFunds,
+            2 * ticketPrice * LotteryConfig.MAX_PARTICIPANTS_NUMBER
+        );
+
+        uint256 balanceBeforeWithdraw = address(this).balance;
+
+        vm.expectEmit();
+        emit ILottery.OrganizerFundsWithdrawn(accessibleFunds);
+
+        lottery.withdrawOrganizerFunds(address(this));
+
+        uint256 balanceAfterWithdraw = address(this).balance;
+
+        vm.assertEq(lottery.organizerFunds(), 0);
+        vm.assertEq(
+            balanceAfterWithdraw,
+            balanceBeforeWithdraw + accessibleFunds
+        );
+    }
+
+    function test_withdrawOrganizerFunds_RevertsIfNoFundsToWithdraw() external {
+        vm.expectRevert(
+            abi.encodeWithSelector(ILotteryErrors.ZeroOrganizerBalance.selector)
+        );
+        lottery.withdrawOrganizerFunds(address(this));
+    }
+
+    function test_withdrawOrganizerFunds_RevertsIfTryingToWithdrawToNonPayable()
+        external
+    {
+        lottery.start();
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        for (uint i = 0; i < LotteryConfig.MAX_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: ticketPrice * 2}(2, "@somecontactdetails");
+        }
+
+        lottery.requestWinner();
+
+        vrfCoordinator.fulfillRandomWords(1, address(lottery));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.WithdrawFailed.selector,
+                address(nonPayable)
+            )
+        );
+        lottery.withdrawOrganizerFunds(address(nonPayable));
+    }
+
+    function test_latestContactDetails_ReturnsLatestContactDetails() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.closeInvalidLottery();
+
+        vm.assertEq(
+            lottery.latestContactDetails(participant),
+            "@somecontactdetails"
+        );
+
+        for (
+            uint i = 0;
+            i < lottery.LOTTERY_DATA_FRESHNESS_INTERVAL() - 1;
+            ++i
+        ) {
+            lottery.start();
+
+            vm.warp(lottery.registrationEndTime());
+
+            lottery.closeInvalidLottery();
+        }
+
+        /* Here we assure that function returns correct data after
+        multiple lotteries if it is still considered fresh. */
+        vm.assertEq(
+            lottery.latestContactDetails(participant),
+            "@somecontactdetails"
+        );
+
+        lottery.start();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@anothercontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.closeInvalidLottery();
+
+        vm.assertEq(
+            lottery.latestContactDetails(participant),
+            "@anothercontactdetails"
+        );
+    }
+
+    function test_latestContactDetails_RevertsIfNoContactDetails() external {
+        address participant = participants[0];
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.NoContactDetails.selector,
+                participant
+            )
+        );
+        lottery.latestContactDetails(participant);
+
+        lottery.start();
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.closeInvalidLottery();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.NoContactDetails.selector,
+                participant
+            )
+        );
+        lottery.latestContactDetails(participant);
+    }
+
+    function test_latestContactDetails_RevertsIfDataIsStale() external {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint256 ticketPrice = lottery.ticketPrice();
+
+        hoax(participant);
+        lottery.enter{value: ticketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        lottery.closeInvalidLottery();
+
+        for (uint i = 0; i < lottery.LOTTERY_DATA_FRESHNESS_INTERVAL(); ++i) {
+            lottery.start();
+
+            vm.warp(lottery.registrationEndTime());
+
+            lottery.closeInvalidLottery();
+        }
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.NoContactDetails.selector,
+                participant
+            )
+        );
+        lottery.latestContactDetails(participant);
+    }
+
+    function test_changeOrganizer_AllowsToChange() external {
+        address newOrganizer = participants[0];
+
+        vm.expectEmit();
+        emit ILottery.OrganizerChanged(address(this), newOrganizer);
+
+        lottery.changeOrganizer(newOrganizer);
+
+        assertTrue(
+            lottery.hasRole(lottery.LOTTERY_ORGANIZER_ROLE(), newOrganizer)
+        );
+        assertFalse(
+            lottery.hasRole(lottery.LOTTERY_ORGANIZER_ROLE(), address(this))
+        );
+    }
+
+    function test_changeOrganizer_RevertsIfTryingToChangeToZeroAddress()
+        external
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(ILotteryErrors.ZeroOrganizerAddress.selector)
+        );
+        lottery.changeOrganizer(address(0));
+    }
+
+    function test_changeNftFallbackRecipient_AllowsToChange() external {
+        address newNftFallbackRecipient = participants[0];
+
+        vm.expectEmit();
+        emit ILottery.NftFallbackRecipientChanged(
+            nftFallbackRecipient,
+            newNftFallbackRecipient
+        );
+
+        lottery.changeNftFallbackRecipient(newNftFallbackRecipient);
+
+        vm.assertEq(lottery.nftFallbackRecipient(), newNftFallbackRecipient);
+    }
+
+    function test_changeNftFallbackRecipient_RevertsIfTryingToChangeToZeroAddress()
+        external
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ZeroNftFallbackRecipientAddress.selector
+            )
+        );
+        lottery.changeNftFallbackRecipient(address(0));
+    }
+
+    function test_changeNftFallbackRecipient_RevertsIfTryingToChangeToAccountWithCode()
+        external
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.HasCode.selector,
+                address(this)
+            )
+        );
+        lottery.changeNftFallbackRecipient(address(this));
+    }
+
+    function test_setTicketPrice_AllowsToSet() external {
+        uint256 initialTicketPrice = lottery.ticketPrice();
+        uint256 newTicketPrice = initialTicketPrice * 2;
+
+        vm.expectEmit();
+        emit ILottery.TicketPriceChanged(initialTicketPrice, newTicketPrice);
+
+        lottery.setTicketPrice(newTicketPrice);
+
+        vm.assertEq(lottery.ticketPrice(), newTicketPrice);
+    }
+
+    function test_setTicketPrice_RevertsIfTryingToSetDuringActiveLottery()
+        external
+    {
+        uint256 initialTicketPrice = lottery.ticketPrice();
+        uint256 newTicketPrice = initialTicketPrice * 2;
+
+        lottery.start();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.OpenedForRegistration,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.setTicketPrice(newTicketPrice);
+
+        for (uint i = 0; i < LotteryConfig.TARGET_PARTICIPANTS_NUMBER; i++) {
+            hoax(participants[i]);
+            lottery.enter{value: initialTicketPrice}(1, "@somecontactdetails");
+        }
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.RegistrationEnded,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.setTicketPrice(newTicketPrice);
+
+        lottery.requestWinner();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.WaitingForReveal,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.setTicketPrice(newTicketPrice);
+    }
+
+    function test_setTicketPrice_RevertsIfTryingToSetAfterLotteryHasBeenConsideredInvalid()
+        external
+    {
+        uint256 initialTicketPrice = lottery.ticketPrice();
+        uint256 newTicketPrice = initialTicketPrice * 2;
+
+        lottery.start();
+
+        address participant = participants[0];
+
+        hoax(participant);
+        lottery.enter{value: initialTicketPrice}(1, "@somecontactdetails");
+
+        vm.warp(lottery.registrationEndTime());
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.IncorrectLotteryStatus.selector,
+                Types.LotteryStatus.Invalid,
+                Types.LotteryStatus.Closed
+            )
+        );
+        lottery.setTicketPrice(newTicketPrice);
+    }
+
+    function test_setTicketPrice_RevertsIfTryingToSetZeroTicketPrice()
+        external
+    {
+        vm.expectRevert(
+            abi.encodeWithSelector(ILotteryErrors.ZeroTicketPrice.selector)
+        );
+        lottery.setTicketPrice(0);
     }
 }

--- a/test/Lottery.t.sol
+++ b/test/Lottery.t.sol
@@ -438,6 +438,26 @@ contract LotteryTest is Test {
         lottery.enter(0, "@somecontactdetails");
     }
 
+    function test_enter_RevertsIfTryingToEnterWithZeroLengthContactDetails()
+        external
+    {
+        lottery.start();
+
+        address participant = participants[0];
+
+        uint ticketPrice = lottery.ticketPrice();
+
+        startHoax(participant);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILotteryErrors.ZeroLengthContactDetails.selector,
+                participant
+            )
+        );
+        lottery.enter{value: ticketPrice}(1, "");
+    }
+
     function test_enter_RevertsIfPaymentAmountIsIncorrect() external {
         lottery.start();
 

--- a/test/mocks/NonPayable.sol
+++ b/test/mocks/NonPayable.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/**
+ * @dev Contract without receive() function for testing.
+ */
+contract NonPayable {
+
+}


### PR DESCRIPTION
Tests (Lottery.sol):
- Lines coverage: 99.56% (225/226) (one missing line is from _findWinnerFromUsers(), where _nftFallbackRecipient is returned in case that is normally impossible)
- Statements coverage: 99.57% (231/232) (same as above)
- Branches coverage: 100.00% (81/81)
- Functions coverage: 100.00% (30/30)

Minor changes: 
- returnTickets() refactor: participant removal logic is now separate internal _removeParticipant() function
- Added getter functions totalTicketsCount() and userTicketsCount() that return total amount of tickets sold by all participants and by particular user respectively
- Separated NFT fallback recipient and organizer addresses, so organizer could have code, while NFT fallback recipient does not. NFT fallback recipient is used in the case mentioned above and in the situation when the lottery winner account has non-zero code length. Despite the fact that we check participants code length in enter(), with EIP-7702 it is possible for users to sign and attach delegations whenever they want, so corresponding code length changes respectively
- Changed latestContactDetails() logic: now it returns latest contact details from last LOTTERY_FRESHNESS_DATA_INTERVAL (currently is equal to 5) lotteries instead of current (or recently ended in the sense that the new one has not started yet)
- Renamed InsufficientFunds() error to IncorrectPaymentAmount(), because it handles case when sent ether is greater than required as well
- Added necessity to specify recipient at withdrawOrganizerFunds() and collectExpiredRefunds() to avoid validation that organizer account is able to receive funds (if account related to organizer address had code)
- Made organizer and NFT fallback recipient addresses public variables
- Moved organizer and NFT fallback recipient addresses setting to internal functions, which also added missing requirements to constructor() (zero code length check for NFT fallback recipient, zero address check for both)
- Updated revert parameters in enter() and buyMoreTickets() in case of incorrect payment amount: before that fix 'needed' parameter returned single ticket price rather than entire actual cost required to send
- Added check for positive contact details length in enter()
- Reorganized internal functions, so ones with 'view' modifier go first
- Updated scripts
- Updated README
- Removed 'forge fmt' from CI